### PR TITLE
Import dialoghelpers from Qt 5.8 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ make && make install
 You can use this platform theme by setting the QT_QPA_PLATFORMTHEME to "qgnomeplatform" - so for example putting the following command in your `.bashrc` works well:
 
 ```
-export QT_QPA_PLATFORMTHEME='kde'
+export QT_QPA_PLATFORMTHEME='qgnomeplatform'
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 QGnomePlatform
 ==========
 
-QGnomePlatform is a Qt Platform Theme aimed to accomodate as much of GNOME settings as possible and utilize them in Qt applications without modifying them - making them fit into the environment as well as possible.
+QGnomePlatform is a Qt Platform Theme aimed to accommodate as much of GNOME settings as possible and utilize them in Qt applications without modifying them - making them fit into the environment as well as possible.
 
 ## How to compile
 

--- a/qgnomeplatform.pro
+++ b/qgnomeplatform.pro
@@ -2,8 +2,7 @@ TEMPLATE = lib
 
 CONFIG += plugin \
           c++11 \
-          link_pkgconfig \
-          no_keywords
+          link_pkgconfig
 
 QT += core-private \
       gui-private \
@@ -19,8 +18,10 @@ INSTALLS += target
 
 SOURCES += src/platformplugin.cpp \
            src/qgnomeplatformtheme.cpp \
-           src/gnomehintssettings.cpp
+           src/gnomehintssettings.cpp \
+           src/qgtk3dialoghelpers.cpp
 
 HEADERS += src/platformplugin.h \
            src/qgnomeplatformtheme.h \
-           src/gnomehintssettings.h
+           src/gnomehintssettings.h \
+           src/qgtk3dialoghelpers.h

--- a/src/gnomehintssettings.cpp
+++ b/src/gnomehintssettings.cpp
@@ -193,6 +193,10 @@ void GnomeHintsSettings::fontChanged()
 
     if (qobject_cast<QApplication *>(QCoreApplication::instance())) {
         QApplication::setFont(*m_fonts[QPlatformTheme::SystemFont]);
+        QWidgetList widgets = QApplication::allWidgets();
+        Q_FOREACH (QWidget *widget, widgets) {
+            widget->setFont(*m_fonts[QPlatformTheme::SystemFont]);
+        }
     } else {
         QGuiApplication::setFont(*m_fonts[QPlatformTheme::SystemFont]);
     }

--- a/src/gnomehintssettings.cpp
+++ b/src/gnomehintssettings.cpp
@@ -118,6 +118,7 @@ GnomeHintsSettings::GnomeHintsSettings()
     g_signal_connect(m_settings, "changed::cursor-blink-time", G_CALLBACK(gsettingPropertyChanged), this);
     g_signal_connect(m_settings, "changed::font-name", G_CALLBACK(gsettingPropertyChanged), this);
     g_signal_connect(m_settings, "changed::monospace-font-name", G_CALLBACK(gsettingPropertyChanged), this);
+    g_signal_connect(m_settings, "changed::text-scaling-factor", G_CALLBACK(gsettingPropertyChanged), this);
 
     // g_signal_connect(gtk_settings_get_default(), "notify::gtk-theme-name", G_CALLBACK(gtkThemeChanged), this);
 
@@ -156,6 +157,8 @@ void GnomeHintsSettings::gsettingPropertyChanged(GSettings *settings, gchar *key
     } else if (changedProperty == QLatin1String("font-name")) {
         gnomeHintsSettings->fontChanged();
     } else if (changedProperty == QLatin1String("monospace-font-name")) {
+        gnomeHintsSettings->fontChanged();
+    } else if (changedProperty == QLatin1String("text-scaling-factor")) {
         gnomeHintsSettings->fontChanged();
     } else {
         qCDebug(QGnomePlatform) << "GSetting property change: " << key;
@@ -243,7 +246,8 @@ void GnomeHintsSettings::themeChanged()
 
 void GnomeHintsSettings::loadFonts()
 {
-//     gdouble scaling = g_settings_get_double(m_settings, "text-scaling-factor");
+    gdouble scaling = g_settings_get_double(m_settings, "text-scaling-factor");
+    qCDebug(QGnomePlatform) << "Font scaling: " << scaling;
 
     const QStringList fontTypes { "font-name", "monospace-font-name" };
 
@@ -258,10 +262,10 @@ void GnomeHintsSettings::loadFonts()
             if (re.indexIn(fontNameString) == 0) {
                 fontSize = re.cap(2).toInt();
                 if (fontType == QLatin1String("font-name")) {
-                    m_fonts[QPlatformTheme::SystemFont] = new QFont(re.cap(1), fontSize, QFont::Normal);
+                    m_fonts[QPlatformTheme::SystemFont] = new QFont(re.cap(1), fontSize * scaling, QFont::Normal);
                     qCDebug(QGnomePlatform) << "Font name: " << re.cap(1) << " (size " << fontSize << ")";
                 } else if (fontType == QLatin1String("monospace-font-name")) {
-                    m_fonts[QPlatformTheme::FixedFont] = new QFont(re.cap(1), fontSize, QFont::Normal);
+                    m_fonts[QPlatformTheme::FixedFont] = new QFont(re.cap(1), fontSize * scaling, QFont::Normal);
                     qCDebug(QGnomePlatform) << "Monospace font name: " << re.cap(1) << " (size " << fontSize << ")";
                 }
             } else {

--- a/src/gnomehintssettings.cpp
+++ b/src/gnomehintssettings.cpp
@@ -96,7 +96,7 @@ GnomeHintsSettings::GnomeHintsSettings()
     } else {
         m_hints[QPlatformTheme::SystemIconThemeName] = "Adwaita";
     }
-    m_hints[QPlatformTheme::SystemIconFallbackThemeName] = "Adwaita";
+    m_hints[QPlatformTheme::SystemIconFallbackThemeName] = "breeze";
     m_hints[QPlatformTheme::IconThemeSearchPaths] = xdgIconThemePaths();
 
     QStringList styleNames;

--- a/src/gnomehintssettings.cpp
+++ b/src/gnomehintssettings.cpp
@@ -26,8 +26,8 @@
 #include <QApplication>
 #include <QGuiApplication>
 #include <QDialogButtonBox>
-#include <QtGui/QToolBar>
-#include <QtCore/QLoggingCategory>
+#include <QToolBar>
+#include <QLoggingCategory>
 
 #include <gtk-3.0/gtk/gtksettings.h>
 

--- a/src/gnomehintssettings.cpp
+++ b/src/gnomehintssettings.cpp
@@ -101,7 +101,8 @@ GnomeHintsSettings::GnomeHintsSettings()
 
     QStringList styleNames;
     styleNames << QStringLiteral("adwaita")
-               << QStringLiteral("gtk+")
+               // Avoid using gtk+ style as it uses gtk2 and we use gtk3 which is causing a crash
+               // << QStringLiteral("gtk+")
                << QStringLiteral("fusion")
                << QStringLiteral("windows");
     m_hints[QPlatformTheme::StyleNames] = styleNames;

--- a/src/gnomehintssettings.h
+++ b/src/gnomehintssettings.h
@@ -24,6 +24,7 @@
 #include <QObject>
 #include <QVariant>
 
+#undef signals
 #include <gio/gio.h>
 #include <qpa/qplatformtheme.h>
 

--- a/src/qgnomeplatformtheme.cpp
+++ b/src/qgnomeplatformtheme.cpp
@@ -19,6 +19,7 @@
 
 #include "qgnomeplatformtheme.h"
 #include "gnomehintssettings.h"
+#include "qgtk3dialoghelpers.h"
 #include <QApplication>
 #include <QStyleFactory>
 
@@ -54,15 +55,22 @@ const QPalette *QGnomePlatformTheme::palette(Palette type) const
 
 bool QGnomePlatformTheme::usePlatformNativeDialog(QPlatformTheme::DialogType type) const
 {
-    Q_UNUSED(type);
-    // TODO provide native file dialog
-    return false;
+    switch (type) {
+    case QPlatformTheme::FileDialog:
+        return true;
+    case QPlatformTheme::FontDialog:
+    case QPlatformTheme::ColorDialog:
+    case QPlatformTheme::MessageDialog:
+    default:
+        return false;
+    }
 }
 
 QPlatformDialogHelper *QGnomePlatformTheme::createPlatformDialogHelper(QPlatformTheme::DialogType type) const
 {
     switch (type) {
-    case QPlatformTheme::FileDialog: // TODO provide native file dialog
+    case QPlatformTheme::FileDialog:
+        return new QGtk3FileDialogHelper();
     case QPlatformTheme::FontDialog:
     case QPlatformTheme::ColorDialog:
     case QPlatformTheme::MessageDialog:

--- a/src/qgnomeplatformtheme.cpp
+++ b/src/qgnomeplatformtheme.cpp
@@ -59,7 +59,9 @@ bool QGnomePlatformTheme::usePlatformNativeDialog(QPlatformTheme::DialogType typ
     case QPlatformTheme::FileDialog:
         return true;
     case QPlatformTheme::FontDialog:
+        return true;
     case QPlatformTheme::ColorDialog:
+        return true;
     case QPlatformTheme::MessageDialog:
     default:
         return false;
@@ -72,7 +74,9 @@ QPlatformDialogHelper *QGnomePlatformTheme::createPlatformDialogHelper(QPlatform
     case QPlatformTheme::FileDialog:
         return new QGtk3FileDialogHelper();
     case QPlatformTheme::FontDialog:
+        return new QGtk3FontDialogHelper();
     case QPlatformTheme::ColorDialog:
+        return new QGtk3ColorDialogHelper();
     case QPlatformTheme::MessageDialog:
     default:
         return 0;

--- a/src/qgnomeplatformtheme.cpp
+++ b/src/qgnomeplatformtheme.cpp
@@ -55,7 +55,20 @@ const QPalette *QGnomePlatformTheme::palette(Palette type) const
 bool QGnomePlatformTheme::usePlatformNativeDialog(QPlatformTheme::DialogType type) const
 {
     Q_UNUSED(type);
-    return true;
+    // TODO provide native file dialog
+    return false;
+}
+
+QPlatformDialogHelper *QGnomePlatformTheme::createPlatformDialogHelper(QPlatformTheme::DialogType type) const
+{
+    switch (type) {
+    case QPlatformTheme::FileDialog: // TODO provide native file dialog
+    case QPlatformTheme::FontDialog:
+    case QPlatformTheme::ColorDialog:
+    case QPlatformTheme::MessageDialog:
+    default:
+        return 0;
+    }
 }
 
 const QFont *QGnomePlatformTheme::font(Font type) const

--- a/src/qgnomeplatformtheme.cpp
+++ b/src/qgnomeplatformtheme.cpp
@@ -65,6 +65,11 @@ void QGnomePlatformTheme::getFont() {
     gchar *name = g_settings_get_string(m_settings, "font-name");
     if (!name)
         return;
+    gchar *fixed = g_settings_get_string(m_settings, "monospace-font-name");
+    if (!fixed) {
+        free(name);
+        return;
+    }
 
     QString rawFont(name);
 
@@ -72,15 +77,17 @@ void QGnomePlatformTheme::getFont() {
         delete m_font;
 
     QRegExp re("(.+)[ \t]+([0-9]+)");
+    int fontSize;
     if (re.indexIn(rawFont) == 0) {
-        m_font = new QFont(re.cap(1), re.cap(2).toInt(), QFont::Normal);
+        fontSize = re.cap(2).toInt();
+        m_font = new QFont(re.cap(1), fontSize, QFont::Normal);
     }
     else {
         m_font = new QFont(rawFont);
+        fontSize = m_font->pixelSize();
     }
 
-    qCritical() << m_font->pointSizeF() << scaling;
-    m_font->setPointSizeF(m_font->pointSizeF() * sqrt(scaling));
+    m_font->setPixelSize(fontSize * scaling);
 
     QGuiApplication::setFont(*m_font);
 

--- a/src/qgnomeplatformtheme.h
+++ b/src/qgnomeplatformtheme.h
@@ -36,6 +36,7 @@ public:
     const QFont *font(Font type) const Q_DECL_OVERRIDE;
     const QPalette *palette(Palette type = SystemPalette) const Q_DECL_OVERRIDE;
     bool usePlatformNativeDialog(DialogType type) const Q_DECL_OVERRIDE;
+    QPlatformDialogHelper *createPlatformDialogHelper(DialogType type) const Q_DECL_OVERRIDE;
 
 private:
     void loadSettings();

--- a/src/qgtk3dialoghelpers.cpp
+++ b/src/qgtk3dialoghelpers.cpp
@@ -218,7 +218,6 @@ void QGtk3ColorDialogHelper::onAccepted()
     const QColor color = currentColor();
     emit currentColorChanged(color);
     emit accept();
-    emit colorSelected(color);
 }
 
 void QGtk3ColorDialogHelper::onColorChanged(QGtk3ColorDialogHelper *dialog)

--- a/src/qgtk3dialoghelpers.cpp
+++ b/src/qgtk3dialoghelpers.cpp
@@ -361,10 +361,14 @@ void QGtk3FileDialogHelper::onAccepted()
     if (filter.isEmpty())
         emit filterSelected(filter);
 
+    // These signals are emitted by QFileDialog::accept(), don't emit them twice
+    /*
     QList<QUrl> files = selectedFiles();
     emit filesSelected(files);
     if (files.count() == 1)
         emit fileSelected(files.first());
+    */
+
 }
 
 void QGtk3FileDialogHelper::onSelectionChanged(GtkDialog *gtkDialog, QGtk3FileDialogHelper *helper)

--- a/src/qgtk3dialoghelpers.cpp
+++ b/src/qgtk3dialoghelpers.cpp
@@ -597,7 +597,6 @@ void QGtk3FontDialogHelper::onAccepted()
     const QFont font = currentFont();
     emit currentFontChanged(font);
     emit accept();
-    emit fontSelected(font);
 }
 
 void QGtk3FontDialogHelper::applyOptions()


### PR DESCRIPTION
This enables native Gtk3 file chooser, font chooser and color chooser dialogs. The helper classes were imported from the gtk3 platform theme in the current Qt 5.8 branch. They may require some more testing before merging but so far I haven't found any issues with the Qt applications I'm using.