### PR TITLE
Added dark/light theme switch.

### DIFF
--- a/src/gnomehintssettings.cpp
+++ b/src/gnomehintssettings.cpp
@@ -117,6 +117,9 @@ GnomeHintsSettings::GnomeHintsSettings()
     m_hints[QPlatformTheme::IconThemeSearchPaths] = xdgIconThemePaths();
 
     QStringList styleNames;
+    if (m_gtkThemeDarkVariant) {
+        styleNames << QStringLiteral("adwaita-dark");
+    }
     styleNames << QStringLiteral("adwaita")
                // Avoid using gtk+ style as it uses gtk2 and we use gtk3 which is causing a crash
                // << QStringLiteral("gtk+")


### PR DESCRIPTION
This PR prepends the list of style names with "adwaita-dark" if the dark theme is globally enabled. This requires [a modified adwaita](/rokm/adwaita-qt/tree/dark) to actually do anything - otherwise, it should fall back to regular adwaita.
