### PR TITLE
Initialize Pango types in QGnomePlatformTheme constructor

### DIFF
--- a/src/qgnomeplatformtheme.cpp
+++ b/src/qgnomeplatformtheme.cpp
@@ -27,6 +27,12 @@
 QGnomePlatformTheme::QGnomePlatformTheme()
 {
     loadSettings();
+
+    /* Initialize some types here so that Gtk+ does not crash when reading
+     * the treemodel for GtkFontChooser.
+     */
+    g_type_ensure(PANGO_TYPE_FONT_FAMILY);
+    g_type_ensure(PANGO_TYPE_FONT_FACE);
 }
 
 QGnomePlatformTheme::~QGnomePlatformTheme()


### PR DESCRIPTION
Otherwise creating a QGtk3FontDialogHelper will result in a crash.
The same change was applied in qt/qtbase@e8763912068f4501.

Fixes retext-project/retext#247.

The crash happens in `gtk_font_chooser_widget_load_fonts()` function, on [line 754](https://git.gnome.org/browse/gtk+/tree/gtk/gtkfontchooserwidget.c?h=gtk-3-22#n754). It happens because the types are not initialized properly.

Before crash, the following warnings are printed:
```
Gtk-WARNING **: Unknown type PangoFontFamily specified in treemodel model
Gtk-WARNING **: Unknown type PangoFontFace specified in treemodel model
Gtk-WARNING **: gtkliststore.c:516: Invalid type (null)
Gtk-WARNING **: gtkliststore.c:516: Invalid type (null)
GLib-GObject-CRITICAL **: g_value_type_transformable: assertion 'G_TYPE_IS_VALUE (src_type)' failed
GLib-GObject-CRITICAL **: g_value_type_transformable: assertion 'G_TYPE_IS_VALUE (src_type)' failed
GLib-GObject-WARNING **: gtype.c:4264: type id '0' is invalid
GLib-GObject-WARNING **: can't peek value table for type '<invalid>' which is not currently referenced
```