### PR TITLE
Remove button and menu icons

### DIFF
--- a/qgnomeplatform.pro
+++ b/qgnomeplatform.pro
@@ -19,9 +19,11 @@ INSTALLS += target
 SOURCES += src/platformplugin.cpp \
            src/qgnomeplatformtheme.cpp \
            src/gnomehintssettings.cpp \
-           src/qgtk3dialoghelpers.cpp
+           src/qgtk3dialoghelpers.cpp \
+           src/gnomeproxystyle.cpp
 
 HEADERS += src/platformplugin.h \
            src/qgnomeplatformtheme.h \
            src/gnomehintssettings.h \
-           src/qgtk3dialoghelpers.h
+           src/qgtk3dialoghelpers.h \
+           src/gnomeproxystyle.h

--- a/src/gnomehintssettings.cpp
+++ b/src/gnomehintssettings.cpp
@@ -31,6 +31,8 @@
 
 #include <gtk-3.0/gtk/gtksettings.h>
 
+#include "gnomeproxystyle.h"
+
 Q_LOGGING_CATEGORY(QGnomePlatform, "qt.qpa.qgnomeplatform")
 
 void gtkMessageHandler(const gchar *log_domain,
@@ -128,7 +130,6 @@ GnomeHintsSettings::GnomeHintsSettings()
     m_hints[QPlatformTheme::StyleNames] = styleNames;
 
     m_hints[QPlatformTheme::DialogButtonBoxLayout] = QDialogButtonBox::GnomeLayout;
-    m_hints[QPlatformTheme::DialogButtonBoxButtonsHaveIcons] = true;
     m_hints[QPlatformTheme::KeyboardScheme] = QPlatformTheme::GnomeKeyboardScheme;
     m_hints[QPlatformTheme::IconPixmapSizes] = QVariant::fromValue(QList<int>() << 512 << 256 << 128 << 64 << 32 << 22 << 16 << 8);
     m_hints[QPlatformTheme::PasswordMaskCharacter] = QVariant(QChar(0x2022));
@@ -153,8 +154,32 @@ GnomeHintsSettings::GnomeHintsSettings()
     // Load fonts
     loadFonts();
 
-    // Load palette
-    loadPalette();
+    // Disable icons in menus
+    QCoreApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
+
+    // Apply proxy style
+    if (QGuiApplication::desktopSettingsAware()) {
+        // Apply custom style hints before creating QApplication
+        // Using Fusion style should avoid problems with some styles like qtcurve
+        QApplication::setStyle(new GnomeProxyStyle("Fusion"));
+
+        // When QApplication is created, update style to match GTK theme
+        QMetaObject::invokeMethod(this, "updateProxyStyle", Qt::QueuedConnection);
+    } else {
+        // Load palette
+        loadPalette();
+    }
+}
+
+void GnomeHintsSettings::updateProxyStyle()
+{
+    if (qobject_cast<QApplication *> (qApp) != 0) {
+        // Do not override proxy style (fixes crash in qupzilla)
+        QProxyStyle *proxyStyle = qobject_cast<QProxyStyle *>(qApp->style());
+        proxyStyle ? proxyStyle->setBaseStyle(0) : qApp->setStyle(new GnomeProxyStyle(m_gtkTheme));
+    }
+
+    themeChanged();
 }
 
 GnomeHintsSettings::~GnomeHintsSettings()

--- a/src/gnomehintssettings.h
+++ b/src/gnomehintssettings.h
@@ -80,6 +80,7 @@ public Q_SLOTS:
 private Q_SLOTS:
     void loadFonts();
     void loadPalette();
+    void updateProxyStyle();
 
 protected:
     static void gsettingPropertyChanged(GSettings *settings, gchar *key, GnomeHintsSettings *gnomeHintsSettings);

--- a/src/gnomeproxystyle.cpp
+++ b/src/gnomeproxystyle.cpp
@@ -1,0 +1,20 @@
+#include "gnomeproxystyle.h"
+
+GnomeProxyStyle::GnomeProxyStyle(const QString &key) :
+    QProxyStyle(key)
+{
+}
+
+GnomeProxyStyle::~GnomeProxyStyle()
+{
+}
+
+int GnomeProxyStyle::styleHint(QStyle::StyleHint hint, const QStyleOption *option,
+                               const QWidget *widget, QStyleHintReturn *returnData) const
+{
+    if (hint == QStyle::SH_DialogButtonBox_ButtonsHaveIcons) {
+        return 0;
+    }
+
+    return QProxyStyle::styleHint(hint, option, widget, returnData);
+}

--- a/src/gnomeproxystyle.h
+++ b/src/gnomeproxystyle.h
@@ -1,0 +1,16 @@
+#ifndef GNOMEPROXYSTYLE_H
+#define GNOMEPROXYSTYLE_H
+
+#include <QProxyStyle>
+
+class GnomeProxyStyle : public QProxyStyle
+{
+    Q_OBJECT
+public:
+    explicit GnomeProxyStyle(const QString &key);
+    virtual ~GnomeProxyStyle();
+
+    int styleHint(StyleHint hint, const QStyleOption *option, const QWidget *widget, QStyleHintReturn *returnData) const;
+};
+
+#endif // GNOMEPROXYSTYLE_H


### PR DESCRIPTION
This PR fixes issue #17. The way it works was taken from qt5ct project: I've added proxy style which disables button icons.

Menu icons are disabled using Qt::AA_DontShowIconsInMenus flag.

Since in latest GNOME 3.22 there are no settings for menu and dialog button icons, they are just disabled to make Qt apps look more GNOME-ish.