### PR TITLE
make QGnomePlatform qt 5.8 compatible

### DIFF
--- a/qgnomeplatform.pro
+++ b/qgnomeplatform.pro
@@ -6,7 +6,7 @@ CONFIG += plugin \
 
 QT += core-private \
       gui-private \
-      platformsupport-private \
+      theme_support-private \
       widgets
 
 PKGCONFIG += gtk+-3.0 \


### PR DESCRIPTION
replace **platformsupport-private** with  **theme_support-private** in qgnomeplatform.pro 