### PR TITLE
Use QPlatformSystemTrayIcon from QGnomeTheme

### DIFF
--- a/src/qgnomeplatformtheme.cpp
+++ b/src/qgnomeplatformtheme.cpp
@@ -24,6 +24,8 @@
 #include <QApplication>
 #include <QStyleFactory>
 
+#include <QtThemeSupport/private/qgenericunixthemes_p.h>
+
 QGnomePlatformTheme::QGnomePlatformTheme()
 {
     loadSettings();
@@ -33,11 +35,14 @@ QGnomePlatformTheme::QGnomePlatformTheme()
      */
     g_type_ensure(PANGO_TYPE_FONT_FAMILY);
     g_type_ensure(PANGO_TYPE_FONT_FACE);
+
+    m_gnome_theme = new QGnomeTheme;
 }
 
 QGnomePlatformTheme::~QGnomePlatformTheme()
 {
     delete m_hints;
+    delete m_gnome_theme;
 }
 
 QVariant QGnomePlatformTheme::themeHint(QPlatformTheme::ThemeHint hintType) const
@@ -95,10 +100,10 @@ QPlatformDialogHelper *QGnomePlatformTheme::createPlatformDialogHelper(QPlatform
     }
 }
 
-#ifndef QT_NO_SYSTEMTRAYICON
+#if !defined(QT_NO_DBUS) && !defined(QT_NO_SYSTEMTRAYICON)
 QPlatformSystemTrayIcon * QGnomePlatformTheme::createPlatformSystemTrayIcon() const
 {
-    return nullptr;
+    return m_gnome_theme->createPlatformSystemTrayIcon();
 }
 #endif
 

--- a/src/qgnomeplatformtheme.h
+++ b/src/qgnomeplatformtheme.h
@@ -37,7 +37,7 @@ public:
     const QPalette *palette(Palette type = SystemPalette) const Q_DECL_OVERRIDE;
     bool usePlatformNativeDialog(DialogType type) const Q_DECL_OVERRIDE;
     QPlatformDialogHelper *createPlatformDialogHelper(DialogType type) const Q_DECL_OVERRIDE;
-#ifndef QT_NO_SYSTEMTRAYICON
+#if !defined(QT_NO_DBUS) && !defined(QT_NO_SYSTEMTRAYICON)
     virtual QPlatformSystemTrayIcon *createPlatformSystemTrayIcon() const;
 #endif
 
@@ -45,6 +45,7 @@ private:
     void loadSettings();
 
     GnomeHintsSettings *m_hints;
+    QPlatformTheme *m_gnome_theme;
 };
 
 #endif // QGNOME_PLATFORM_THEME_HH


### PR DESCRIPTION
This allows QGnomePlatformTheme to use the system tray implementation from QGnomeTheme. With this in place, AppIndicators can be used where supported--such as when the AppIndicator gnome-shell plugin is installed.